### PR TITLE
Add diary web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# Q
+# Diary Web App with Spotify Integration
+
+This simple project lets you write diary entries with optional photos and an attached Spotify track.
+Entries are stored in your browser's `localStorage` so no backend is required.
+
+## Getting Started
+
+1. Place the files on any static web server (or open `index.html` directly).
+2. Before searching Spotify, store an access token in `localStorage`:
+   - Open developer tools console and run:
+     ```javascript
+     localStorage.setItem('spotify_token', 'YOUR_ACCESS_TOKEN');
+     ```
+   - You can generate a token from the [Spotify Web API Console](https://developer.spotify.com/console/post-search-item/).
+3. Use the `New Entry` button to create a diary entry. After saving, entries appear on the home page.
+4. Use the theme selector to switch between light and dark modes.
+
+This project is a minimal proof of concept and does not include authentication or a database.

--- a/diary.html
+++ b/diary.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>New Diary Entry</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body id="diary">
+    <div id="theme-toggle">
+        <label for="themeSelect">Theme:</label>
+        <select id="themeSelect">
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+        </select>
+    </div>
+    <h1>Write a Diary</h1>
+    <div id="question"></div>
+    <form id="diaryForm">
+        <label>
+            Date:
+            <input type="date" id="entryDate" required>
+        </label>
+        <label>
+            Text:
+            <textarea id="entryText" required></textarea>
+        </label>
+        <label>
+            Photo:
+            <input type="file" id="entryPhoto" accept="image/*">
+        </label>
+        <div id="spotify">
+            <input type="text" id="spotifySearch" placeholder="Search Spotify">
+            <button type="button" id="searchBtn">Search</button>
+            <div id="results"></div>
+            <div id="selectedTrack"></div>
+        </div>
+        <button type="submit">Save</button>
+    </form>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Diary Home</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body id="index">
+    <div id="theme-toggle">
+        <label for="themeSelect">Theme:</label>
+        <select id="themeSelect">
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+        </select>
+    </div>
+    <h1>My Diary</h1>
+    <button id="newEntry">New Entry</button>
+    <div id="entries"></div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,158 @@
+const QUESTIONS = [
+    "How was your day?",
+    "What made you smile today?",
+    "Did you learn anything new?"
+];
+
+function applyTheme() {
+    const theme = localStorage.getItem('theme') || 'light';
+    document.body.classList.remove('light', 'dark');
+    document.body.classList.add(theme);
+    const select = document.getElementById('themeSelect');
+    if (select) select.value = theme;
+}
+
+function setupThemeToggle() {
+    const select = document.getElementById('themeSelect');
+    if (!select) return;
+    select.addEventListener('change', () => {
+        localStorage.setItem('theme', select.value);
+        applyTheme();
+    });
+}
+
+function randomQuestion() {
+    return QUESTIONS[Math.floor(Math.random() * QUESTIONS.length)];
+}
+
+function saveEntry(entry) {
+    const entries = JSON.parse(localStorage.getItem('entries') || '[]');
+    entries.push(entry);
+    localStorage.setItem('entries', JSON.stringify(entries));
+}
+
+function loadEntries() {
+    const container = document.getElementById('entries');
+    if (!container) return;
+    const entries = JSON.parse(localStorage.getItem('entries') || '[]');
+    entries.forEach(e => {
+        const div = document.createElement('div');
+        div.innerHTML = `<strong>${e.date}</strong><p>${e.text}</p>`;
+        if (e.photo) {
+            const img = document.createElement('img');
+            img.src = e.photo;
+            img.width = 200;
+            div.appendChild(img);
+        }
+        if (e.track) {
+            const trackDiv = document.createElement('div');
+            trackDiv.innerHTML = `<p>${e.track.name} - ${e.track.artist}</p>`;
+            if (e.track.preview_url) {
+                const audio = document.createElement('audio');
+                audio.controls = true;
+                audio.src = e.track.preview_url;
+                trackDiv.appendChild(audio);
+            }
+            div.appendChild(trackDiv);
+        }
+        container.appendChild(div);
+    });
+}
+
+function onIndexLoad() {
+    const btn = document.getElementById('newEntry');
+    if (btn) {
+        btn.addEventListener('click', () => {
+            window.location.href = 'diary.html';
+        });
+    }
+    loadEntries();
+}
+
+function onDiaryLoad() {
+    const questionDiv = document.getElementById('question');
+    if (questionDiv) questionDiv.textContent = randomQuestion();
+
+    const form = document.getElementById('diaryForm');
+    const photoInput = document.getElementById('entryPhoto');
+    let selectedTrack = null;
+
+    const searchBtn = document.getElementById('searchBtn');
+    const resultsDiv = document.getElementById('results');
+    const selectedDiv = document.getElementById('selectedTrack');
+    const searchInput = document.getElementById('spotifySearch');
+
+    const token = localStorage.getItem('spotify_token'); // user must set this
+
+    if (searchBtn) {
+        searchBtn.addEventListener('click', () => {
+            const q = searchInput.value.trim();
+            if (!q || !token) return;
+            fetch(`https://api.spotify.com/v1/search?type=track&q=${encodeURIComponent(q)}`, {
+                headers: { Authorization: `Bearer ${token}` }
+            })
+            .then(r => r.json())
+            .then(data => {
+                resultsDiv.innerHTML = '';
+                (data.tracks.items || []).forEach(track => {
+                    const div = document.createElement('div');
+                    div.innerHTML = `<img src="${track.album.images[2]?.url}" alt="">
+                        ${track.name} - ${track.artists[0].name}`;
+                    const btn = document.createElement('button');
+                    btn.textContent = 'Select';
+                    btn.addEventListener('click', () => {
+                        selectedTrack = {
+                            id: track.id,
+                            name: track.name,
+                            artist: track.artists[0].name,
+                            preview_url: track.preview_url
+                        };
+                        selectedDiv.textContent = `${track.name} - ${track.artists[0].name}`;
+                        if (track.preview_url) {
+                            const audio = document.createElement('audio');
+                            audio.controls = true;
+                            audio.src = track.preview_url;
+                            selectedDiv.appendChild(audio);
+                        }
+                    });
+                    div.appendChild(btn);
+                    resultsDiv.appendChild(div);
+                });
+            });
+        });
+    }
+
+    if (form) {
+        form.addEventListener('submit', (e) => {
+            e.preventDefault();
+            const reader = new FileReader();
+            const entry = {
+                date: document.getElementById('entryDate').value,
+                text: document.getElementById('entryText').value,
+                photo: null,
+                track: selectedTrack
+            };
+            if (photoInput.files[0]) {
+                reader.onload = () => {
+                    entry.photo = reader.result;
+                    saveEntry(entry);
+                    window.location.href = 'index.html';
+                };
+                reader.readAsDataURL(photoInput.files[0]);
+            } else {
+                saveEntry(entry);
+                window.location.href = 'index.html';
+            }
+        });
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    applyTheme();
+    setupThemeToggle();
+    if (document.body.id === 'index') {
+        onIndexLoad();
+    } else {
+        onDiaryLoad();
+    }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,31 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 1em;
+    background: var(--bg);
+    color: var(--fg);
+}
+
+body.light {
+    --bg: #ffffff;
+    --fg: #000000;
+}
+
+body.dark {
+    --bg: #121212;
+    --fg: #ffffff;
+}
+
+#entries > div {
+    border: 1px solid #ccc;
+    padding: 1em;
+    margin-bottom: 1em;
+}
+
+#results img {
+    height: 64px;
+}
+
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- create index page showing entries and theme switcher
- add diary entry page with Spotify search and photo upload
- style light/dark themes
- implement logic in script.js and add setup info to README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6851205412ac832b81d9b68951d76a86